### PR TITLE
Update documentation for multi-line strings

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,8 @@
 name: "test deploy to cloud.gov"
 
 on:
+  push:
+    branches: [ main ]
   pull_request:
     branches: [ main ]
 

--- a/.github/workflows/main_pr.yml
+++ b/.github/workflows/main_pr.yml
@@ -1,7 +1,7 @@
 name: "test deploy to cloud.gov"
 
 on:
-  push:
+  pull_request:
     branches: [ main ]
 
 jobs:

--- a/.github/workflows/main_pr.yml
+++ b/.github/workflows/main_pr.yml
@@ -21,7 +21,9 @@ jobs:
           cf_org: ${{ secrets.CF_ORG }}
           cf_space: ${{ secrets.CF_SPACE }}
           app_directory: ./test_site
-          push_arguments: "--vars-file deployment_config.yml --var cf_space=$CFSPACE"
+          push_arguments: >-
+            --vars-file deployment_config.yml
+            --var cf_space="$CFSPACE"
 
       - name: "Run set-env command"
         uses: ./

--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ jobs:
           cf_password: ${{ secrets.CF_PASSWORD }}
           cf_org: my-org-name
           cf_space: my-space-name
-          push_arguments: "--vars-file deploy_config.yml --var other_secret=$OTHER_SECRET"
+          push_arguments: >-
+            --vars-file deploy_config.yml
+            --var other_secret="$OTHER_SECRET"
 
       - name: Set environment variable
         uses: 18f/cg-deploy-action@main
@@ -33,6 +35,10 @@ jobs:
           cf_space: my-space-name
           full_command: "cf set-env APP_NAME DEPLOYED_SHA $GITHUB_SHA"
 ```
+
+### Important Gotcha
+
+To use multiline strings for `push_arguments` or `full_command` use the `>-` form that tells yaml to strip out newlines
 
 ## Inputs
 


### PR DESCRIPTION
Update examples and README to use a mutli-line string format for `push_arguments` that is

1. clearer than jamming everything into one long line
2. doesn't introduce a syntax bug by adding an unexpected newline into an interpolated string

closes #2 